### PR TITLE
Persist Jupyter session across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ To use this functionality from an OSCAR cluster, you simply need to enter the Da
 
 You also can use the `juno.yaml` and `script.sh`, presents in this repository and deploy it as an OSCAR service. Note that by default it will deploy the `full` version with Elyra and APRICOTLab.
 
+JUNO stores the Jupyter runtime directory and cookie secret under
+`$JUPYTER_DIRECTORY/.jupyter/runtime` by default. When `$JUPYTER_DIRECTORY` is
+mounted on persistent storage, dashboard links that include `?token=...` keep
+working after the OSCAR exposed service is stopped and started again.
+
 ## Examples
 
 If you go to the examples directory, you can find a simple tutorial that will teach you how to use OSCAR through Jupyter Notebooks with two basic use cases.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ To use this functionality from an OSCAR cluster, you simply need to enter the Da
 
 You also can use the `juno.yaml` and `script.sh`, presents in this repository and deploy it as an OSCAR service. Note that by default it will deploy the `full` version with Elyra and APRICOTLab.
 
-JUNO stores the Jupyter runtime directory and cookie secret under
-`$JUPYTER_DIRECTORY/.jupyter/runtime` by default. When `$JUPYTER_DIRECTORY` is
+JUNO stores a persistent copy of the Jupyter cookie secret under
+`$JUPYTER_DIRECTORY/.jupyter/jupyter_cookie_secret` by default and copies it to
+a local runtime file before starting Jupyter. When `$JUPYTER_DIRECTORY` is
 mounted on persistent storage, dashboard links that include `?token=...` keep
 working after the OSCAR exposed service is stopped and started again.
 

--- a/examples/s3/script.sh
+++ b/examples/s3/script.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -eu
+
 sleep 15
 export GIT_REPO="grycap/oscar-juno"
 export OSCAR_REPO="grycap/oscar"
@@ -26,6 +29,23 @@ shutil.copyfile(persistent_secret, runtime_secret)
 runtime_secret.chmod(0o600)
 PY
 
+download_if_missing() {
+    url="$1"
+    destination="$2"
+
+    if [ -s "$destination" ]; then
+        return 0
+    fi
+
+    tmp_destination="${destination}.tmp"
+    if curl -fsSL --retry 3 --retry-delay 2 "$url" -o "$tmp_destination"; then
+        mv "$tmp_destination" "$destination"
+    else
+        rm -f "$tmp_destination"
+        echo "WARNING: could not download $url" >&2
+    fi
+}
+
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/output"
@@ -33,24 +53,28 @@ mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/output"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/00-setup.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/00-setup.ipynb
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/01-sync.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/01-sync.ipynb
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/02-async.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/02-async.ipynb
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/00-setup.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/00-setup.ipynb"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/01-sync.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/01-sync.ipynb"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/02-async.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/02-async.ipynb"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/cowsay-sync.yaml > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/cowsay-sync.yaml
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/plant-async.yaml > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/plant-async.yaml
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/cowsay-sync.yaml" "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/cowsay-sync.yaml"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/plant-async.yaml" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/plant-async.yaml"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/script_cowsay_sync.sh > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/script_cowsay_sync.sh
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/script_plant_async.sh > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/script_plant_async.sh
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/script_cowsay_sync.sh" "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/script_cowsay_sync.sh"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/script_plant_async.sh" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/script_plant_async.sh"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-input.jpg > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-input.jpg
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-output.jpg > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-output.jpg
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/oscar_tutorial.pipeline > $JUPYTER_DIRECTORY/oscar-tutorial/oscar_tutorial.pipeline
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-input.jpg" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-input.jpg"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-output.jpg" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-output.jpg"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/oscar_tutorial.pipeline" "$JUPYTER_DIRECTORY/oscar-tutorial/oscar_tutorial.pipeline"
 
-curl https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_tutorial.ipynb > $JUPYTER_DIRECTORY/apricot-tutorial.ipynb
-curl https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_magics/apricot_magics.py > $JUPYTER_DIRECTORY/apricot_magics.py
-sed -i 's/resources_dir = current_dir.parent \/ "resources"/resources_dir = current_dir \/ "resources"/g' $JUPYTER_DIRECTORY/apricot_magics.py
+download_if_missing "https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_tutorial.ipynb" "$JUPYTER_DIRECTORY/apricot-tutorial.ipynb"
+download_if_missing "https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_magics/apricot_magics.py" "$JUPYTER_DIRECTORY/apricot_magics.py"
+if [ -f "$JUPYTER_DIRECTORY/apricot_magics.py" ]; then
+    sed -i 's/resources_dir = current_dir.parent \/ "resources"/resources_dir = current_dir \/ "resources"/g' "$JUPYTER_DIRECTORY/apricot_magics.py"
+fi
 
-cp  /apricotlab/resources/ $JUPYTER_DIRECTORY -r
+if [ -d /apricotlab/resources ] && [ ! -e "$JUPYTER_DIRECTORY/resources" ]; then
+    cp -r /apricotlab/resources "$JUPYTER_DIRECTORY"
+fi
 
-jupyter lab --ServerApp.allow_root=True  --Session.username=root  --ServerApp.base_url=$JHUB_BASE_URL --IdentityProvider.token=$JUPYTER_TOKEN --ServerApp.cookie_secret_file="$JUPYTER_COOKIE_SECRET_FILE" --ServerApp.root_dir=$JUPYTER_DIRECTORY --ip=0.0.0.0 --no-browser 
+exec jupyter lab --ServerApp.allow_root=True --Session.username=root --ServerApp.base_url="$JHUB_BASE_URL" --IdentityProvider.token="$JUPYTER_TOKEN" --ServerApp.cookie_secret_file="$JUPYTER_COOKIE_SECRET_FILE" --ServerApp.root_dir="$JUPYTER_DIRECTORY" --ip=0.0.0.0 --no-browser

--- a/examples/s3/script.sh
+++ b/examples/s3/script.sh
@@ -2,22 +2,28 @@ sleep 15
 export GIT_REPO="grycap/oscar-juno"
 export OSCAR_REPO="grycap/oscar"
 JUPYTER_DIRECTORY="${JUPYTER_DIRECTORY:-/mnt/home}"
-JUPYTER_RUNTIME_DIR="${JUPYTER_RUNTIME_DIR:-$JUPYTER_DIRECTORY/.jupyter/runtime}"
-JUPYTER_COOKIE_SECRET_FILE="${JUPYTER_COOKIE_SECRET_FILE:-$JUPYTER_RUNTIME_DIR/jupyter_cookie_secret}"
+PERSISTENT_JUPYTER_COOKIE_SECRET_FILE="${PERSISTENT_JUPYTER_COOKIE_SECRET_FILE:-$JUPYTER_DIRECTORY/.jupyter/jupyter_cookie_secret}"
+JUPYTER_COOKIE_SECRET_FILE="${JUPYTER_COOKIE_SECRET_FILE:-/tmp/jupyter_cookie_secret}"
 
-mkdir -p "$JUPYTER_DIRECTORY" "$JUPYTER_RUNTIME_DIR"
-export JUPYTER_RUNTIME_DIR
+mkdir -p "$JUPYTER_DIRECTORY" "$(dirname "$PERSISTENT_JUPYTER_COOKIE_SECRET_FILE")"
 export JUPYTER_COOKIE_SECRET_FILE
+export PERSISTENT_JUPYTER_COOKIE_SECRET_FILE
 
 python3 - <<'PY'
 import os
+import shutil
 from pathlib import Path
 
-secret_file = Path(os.environ["JUPYTER_COOKIE_SECRET_FILE"])
-secret_file.parent.mkdir(parents=True, exist_ok=True)
-if not secret_file.exists():
-    secret_file.write_bytes(os.urandom(32))
-    secret_file.chmod(0o600)
+persistent_secret = Path(os.environ["PERSISTENT_JUPYTER_COOKIE_SECRET_FILE"])
+runtime_secret = Path(os.environ["JUPYTER_COOKIE_SECRET_FILE"])
+
+persistent_secret.parent.mkdir(parents=True, exist_ok=True)
+if not persistent_secret.exists():
+    persistent_secret.write_bytes(os.urandom(32))
+
+runtime_secret.parent.mkdir(parents=True, exist_ok=True)
+shutil.copyfile(persistent_secret, runtime_secret)
+runtime_secret.chmod(0o600)
 PY
 
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial"

--- a/examples/s3/script.sh
+++ b/examples/s3/script.sh
@@ -1,13 +1,31 @@
 sleep 15
 export GIT_REPO="grycap/oscar-juno"
 export OSCAR_REPO="grycap/oscar"
-mkdir -p $JUPYTER_DIRECTORY
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/01-sync
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/output
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/02-async
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/02-async/img
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/02-async/output
+JUPYTER_DIRECTORY="${JUPYTER_DIRECTORY:-/mnt/home}"
+JUPYTER_RUNTIME_DIR="${JUPYTER_RUNTIME_DIR:-$JUPYTER_DIRECTORY/.jupyter/runtime}"
+JUPYTER_COOKIE_SECRET_FILE="${JUPYTER_COOKIE_SECRET_FILE:-$JUPYTER_RUNTIME_DIR/jupyter_cookie_secret}"
+
+mkdir -p "$JUPYTER_DIRECTORY" "$JUPYTER_RUNTIME_DIR"
+export JUPYTER_RUNTIME_DIR
+export JUPYTER_COOKIE_SECRET_FILE
+
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+secret_file = Path(os.environ["JUPYTER_COOKIE_SECRET_FILE"])
+secret_file.parent.mkdir(parents=True, exist_ok=True)
+if not secret_file.exists():
+    secret_file.write_bytes(os.urandom(32))
+    secret_file.chmod(0o600)
+PY
+
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/output"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/output"
 
 curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/00-setup.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/00-setup.ipynb
 curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/01-sync.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/01-sync.ipynb
@@ -29,4 +47,4 @@ sed -i 's/resources_dir = current_dir.parent \/ "resources"/resources_dir = curr
 
 cp  /apricotlab/resources/ $JUPYTER_DIRECTORY -r
 
-jupyter lab --ServerApp.allow_root=True  --Session.username=root  --ServerApp.base_url=$JHUB_BASE_URL --IdentityProvider.token=$JUPYTER_TOKEN  --ServerApp.root_dir=$JUPYTER_DIRECTORY --ip=0.0.0.0 --no-browser 
+jupyter lab --ServerApp.allow_root=True  --Session.username=root  --ServerApp.base_url=$JHUB_BASE_URL --IdentityProvider.token=$JUPYTER_TOKEN --ServerApp.cookie_secret_file="$JUPYTER_COOKIE_SECRET_FILE" --ServerApp.root_dir=$JUPYTER_DIRECTORY --ip=0.0.0.0 --no-browser 

--- a/script.sh
+++ b/script.sh
@@ -1,3 +1,6 @@
+#!/bin/sh
+set -eu
+
 sleep 15
 
 export GIT_REPO="grycap/oscar-juno"
@@ -27,7 +30,24 @@ shutil.copyfile(persistent_secret, runtime_secret)
 runtime_secret.chmod(0o600)
 PY
 
-if [ "$IMAGE_VERSION" != "minimal" ]; then
+download_if_missing() {
+    url="$1"
+    destination="$2"
+
+    if [ -s "$destination" ]; then
+        return 0
+    fi
+
+    tmp_destination="${destination}.tmp"
+    if curl -fsSL --retry 3 --retry-delay 2 "$url" -o "$tmp_destination"; then
+        mv "$tmp_destination" "$destination"
+    else
+        rm -f "$tmp_destination"
+        echo "WARNING: could not download $url" >&2
+    fi
+}
+
+if [ "${IMAGE_VERSION:-}" != "minimal" ]; then
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/output"
@@ -36,29 +56,33 @@ mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/output"
 mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/03-elyra"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/00-setup.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/00-setup.ipynb
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/01-sync.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/01-sync.ipynb
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/02-async.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/02-async.ipynb
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/00-setup.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/00-setup.ipynb"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/01-sync.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/01-sync.ipynb"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/02-async.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/02-async.ipynb"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/cowsay-sync.yaml > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/cowsay-sync.yaml
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/plant-async.yaml > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/plant-async.yaml
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/cowsay-sync.yaml" "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/cowsay-sync.yaml"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/plant-async.yaml" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/plant-async.yaml"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/script_cowsay_sync.sh > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/script_cowsay_sync.sh
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/script_plant_async.sh > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/script_plant_async.sh
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/script_cowsay_sync.sh" "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/script_cowsay_sync.sh"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/script_plant_async.sh" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/script_plant_async.sh"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-input.jpg > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-input.jpg
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-output.jpg > $JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-output.jpg
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/oscar_tutorial.pipeline > $JUPYTER_DIRECTORY/oscar-tutorial/oscar_tutorial.pipeline
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-input.jpg" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-input.jpg"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/02-async/img/plant-output.jpg" "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img/plant-output.jpg"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/oscar_tutorial.pipeline" "$JUPYTER_DIRECTORY/oscar-tutorial/oscar_tutorial.pipeline"
 
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/03-elyra/cowsay.pipeline > $JUPYTER_DIRECTORY/oscar-tutorial/03-elyra/cowsay.pipeline
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/03-elyra/setup_client.py > $JUPYTER_DIRECTORY/oscar-tutorial/03-elyra/setup_client.py
-curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/03-elyra/invoke_service_cowsay.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/03-elyra/invoke_service_cowsay.ipynb
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/03-elyra/cowsay.pipeline" "$JUPYTER_DIRECTORY/oscar-tutorial/03-elyra/cowsay.pipeline"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/03-elyra/setup_client.py" "$JUPYTER_DIRECTORY/oscar-tutorial/03-elyra/setup_client.py"
+download_if_missing "https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/03-elyra/invoke_service_cowsay.ipynb" "$JUPYTER_DIRECTORY/oscar-tutorial/03-elyra/invoke_service_cowsay.ipynb"
 
-curl https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_tutorial.ipynb > $JUPYTER_DIRECTORY/apricot-tutorial.ipynb
-curl https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_magics/apricot_magics.py > $JUPYTER_DIRECTORY/apricot_magics.py
-sed -i 's/resources_dir = current_dir.parent \/ "resources"/resources_dir = current_dir \/ "resources"/g' $JUPYTER_DIRECTORY/apricot_magics.py
-
-cp  /apricotlab/resources/ $JUPYTER_DIRECTORY -r
+download_if_missing "https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_tutorial.ipynb" "$JUPYTER_DIRECTORY/apricot-tutorial.ipynb"
+download_if_missing "https://raw.githubusercontent.com/grycap/apricotlab/main/apricot_magics/apricot_magics.py" "$JUPYTER_DIRECTORY/apricot_magics.py"
+if [ -f "$JUPYTER_DIRECTORY/apricot_magics.py" ]; then
+    sed -i 's/resources_dir = current_dir.parent \/ "resources"/resources_dir = current_dir \/ "resources"/g' "$JUPYTER_DIRECTORY/apricot_magics.py"
 fi
 
-jupyter lab --ServerApp.allow_root=True  --Session.username=root  --ServerApp.base_url=$JHUB_BASE_URL --IdentityProvider.token=$JUPYTER_TOKEN --ServerApp.cookie_secret_file="$JUPYTER_COOKIE_SECRET_FILE" --ServerApp.root_dir=$JUPYTER_DIRECTORY --ip=0.0.0.0 --no-browser 
+if [ -d /apricotlab/resources ] && [ ! -e "$JUPYTER_DIRECTORY/resources" ]; then
+    cp -r /apricotlab/resources "$JUPYTER_DIRECTORY"
+fi
+fi
+
+exec jupyter lab --ServerApp.allow_root=True --Session.username=root --ServerApp.base_url="$JHUB_BASE_URL" --IdentityProvider.token="$JUPYTER_TOKEN" --ServerApp.cookie_secret_file="$JUPYTER_COOKIE_SECRET_FILE" --ServerApp.root_dir="$JUPYTER_DIRECTORY" --ip=0.0.0.0 --no-browser

--- a/script.sh
+++ b/script.sh
@@ -2,16 +2,33 @@ sleep 15
 
 export GIT_REPO="grycap/oscar-juno"
 export OSCAR_REPO="grycap/oscar"
-mkdir -p $JUPYTER_DIRECTORY
+JUPYTER_DIRECTORY="${JUPYTER_DIRECTORY:-/mnt/home}"
+JUPYTER_RUNTIME_DIR="${JUPYTER_RUNTIME_DIR:-$JUPYTER_DIRECTORY/.jupyter/runtime}"
+JUPYTER_COOKIE_SECRET_FILE="${JUPYTER_COOKIE_SECRET_FILE:-$JUPYTER_RUNTIME_DIR/jupyter_cookie_secret}"
+
+mkdir -p "$JUPYTER_DIRECTORY" "$JUPYTER_RUNTIME_DIR"
+export JUPYTER_RUNTIME_DIR
+export JUPYTER_COOKIE_SECRET_FILE
+
+python3 - <<'PY'
+import os
+from pathlib import Path
+
+secret_file = Path(os.environ["JUPYTER_COOKIE_SECRET_FILE"])
+secret_file.parent.mkdir(parents=True, exist_ok=True)
+if not secret_file.exists():
+    secret_file.write_bytes(os.urandom(32))
+    secret_file.chmod(0o600)
+PY
 
 if [ "$IMAGE_VERSION" != "minimal" ]; then
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/01-sync
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/output
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/02-async
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/02-async/img
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/02-async/output
-mkdir $JUPYTER_DIRECTORY/oscar-tutorial/03-elyra
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/01-sync/output"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/img"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/02-async/output"
+mkdir -p "$JUPYTER_DIRECTORY/oscar-tutorial/03-elyra"
 
 curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/00-setup.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/00-setup.ipynb
 curl https://raw.githubusercontent.com/$GIT_REPO/master/examples/tutorial/01-sync/01-sync.ipynb > $JUPYTER_DIRECTORY/oscar-tutorial/01-sync/01-sync.ipynb
@@ -38,4 +55,4 @@ sed -i 's/resources_dir = current_dir.parent \/ "resources"/resources_dir = curr
 cp  /apricotlab/resources/ $JUPYTER_DIRECTORY -r
 fi
 
-jupyter lab --ServerApp.allow_root=True  --Session.username=root  --ServerApp.base_url=$JHUB_BASE_URL --IdentityProvider.token=$JUPYTER_TOKEN  --ServerApp.root_dir=$JUPYTER_DIRECTORY --ip=0.0.0.0 --no-browser 
+jupyter lab --ServerApp.allow_root=True  --Session.username=root  --ServerApp.base_url=$JHUB_BASE_URL --IdentityProvider.token=$JUPYTER_TOKEN --ServerApp.cookie_secret_file="$JUPYTER_COOKIE_SECRET_FILE" --ServerApp.root_dir=$JUPYTER_DIRECTORY --ip=0.0.0.0 --no-browser 

--- a/script.sh
+++ b/script.sh
@@ -3,22 +3,28 @@ sleep 15
 export GIT_REPO="grycap/oscar-juno"
 export OSCAR_REPO="grycap/oscar"
 JUPYTER_DIRECTORY="${JUPYTER_DIRECTORY:-/mnt/home}"
-JUPYTER_RUNTIME_DIR="${JUPYTER_RUNTIME_DIR:-$JUPYTER_DIRECTORY/.jupyter/runtime}"
-JUPYTER_COOKIE_SECRET_FILE="${JUPYTER_COOKIE_SECRET_FILE:-$JUPYTER_RUNTIME_DIR/jupyter_cookie_secret}"
+PERSISTENT_JUPYTER_COOKIE_SECRET_FILE="${PERSISTENT_JUPYTER_COOKIE_SECRET_FILE:-$JUPYTER_DIRECTORY/.jupyter/jupyter_cookie_secret}"
+JUPYTER_COOKIE_SECRET_FILE="${JUPYTER_COOKIE_SECRET_FILE:-/tmp/jupyter_cookie_secret}"
 
-mkdir -p "$JUPYTER_DIRECTORY" "$JUPYTER_RUNTIME_DIR"
-export JUPYTER_RUNTIME_DIR
+mkdir -p "$JUPYTER_DIRECTORY" "$(dirname "$PERSISTENT_JUPYTER_COOKIE_SECRET_FILE")"
 export JUPYTER_COOKIE_SECRET_FILE
+export PERSISTENT_JUPYTER_COOKIE_SECRET_FILE
 
 python3 - <<'PY'
 import os
+import shutil
 from pathlib import Path
 
-secret_file = Path(os.environ["JUPYTER_COOKIE_SECRET_FILE"])
-secret_file.parent.mkdir(parents=True, exist_ok=True)
-if not secret_file.exists():
-    secret_file.write_bytes(os.urandom(32))
-    secret_file.chmod(0o600)
+persistent_secret = Path(os.environ["PERSISTENT_JUPYTER_COOKIE_SECRET_FILE"])
+runtime_secret = Path(os.environ["JUPYTER_COOKIE_SECRET_FILE"])
+
+persistent_secret.parent.mkdir(parents=True, exist_ok=True)
+if not persistent_secret.exists():
+    persistent_secret.write_bytes(os.urandom(32))
+
+runtime_secret.parent.mkdir(parents=True, exist_ok=True)
+shutil.copyfile(persistent_secret, runtime_secret)
+runtime_secret.chmod(0o600)
 PY
 
 if [ "$IMAGE_VERSION" != "minimal" ]; then


### PR DESCRIPTION
## Summary
- Persist the Jupyter cookie secret in the mounted notebook workspace and copy it to a local runtime file with secure permissions on startup.
- Keep Jupyter runtime files on local storage to avoid permission errors on mounted volumes.
- Harden the startup scripts with idempotent downloads, quoted paths, guarded optional resources, and exec-based process handoff.

## Why
Stopping and starting an exposed OSCAR Notebook recreated the pod and caused Jupyter to require authentication again from the dashboard link. Persisting only the cookie secret keeps the dashboard session usable across restarts without moving Jupyter runtime state onto the mounted volume.

## Validation
- Deployed and tested through OSCAR/Juno flow: notebook access survives stop/start from the dashboard link.
- `bash -n script.sh examples/s3/script.sh`
- `git diff --check`
